### PR TITLE
QOL changes to aid users who may be using as reference for WLED setup

### DIFF
--- a/macros.d/lights.cfg
+++ b/macros.d/lights.cfg
@@ -17,9 +17,9 @@ gcode:
 [gcode_macro RESETRGB]
 description: Default RGB for display and printer lights
 gcode:
-    SET_LED LED=btt_mini12864 RED=1 GREEN=0.45 BLUE=0.4 INDEX=1 TRANSMIT=0
-    SET_LED LED=btt_mini12864 RED=0.25 GREEN=0.2 BLUE=0.15 INDEX=2 TRANSMIT=0
-    SET_LED LED=btt_mini12864 RED=0.25 GREEN=0.2 BLUE=0.15 INDEX=3
+    SET_LED LED=btt_mini12864 RED=1 GREEN=0.45 BLUE=0.4 INDEX=1 TRANSMIT=0       # Comment out this line if not using a btt_mini12864
+    SET_LED LED=btt_mini12864 RED=0.25 GREEN=0.2 BLUE=0.15 INDEX=2 TRANSMIT=0    # Comment out this line if not using a btt_mini12864
+    SET_LED LED=btt_mini12864 RED=0.25 GREEN=0.2 BLUE=0.15 INDEX=3               # Comment out this line if not using a btt_mini12864
     _LIGHTS_FLICKER
 
 [gcode_macro LCDRGB]
@@ -29,9 +29,9 @@ gcode:
     {% set G = params.G|default(1)|float %}
     {% set B = params.B|default(1)|float %}
 
-    SET_LED LED=btt_mini12864 RED={R} GREEN={G} BLUE={B} INDEX=1 TRANSMIT=0
-    SET_LED LED=btt_mini12864 RED={R} GREEN={G} BLUE={B} INDEX=2 TRANSMIT=0
-    SET_LED LED=btt_mini12864 RED={R} GREEN={G} BLUE={B} INDEX=3 TRANSMIT=1
+    SET_LED LED=btt_mini12864 RED={R} GREEN={G} BLUE={B} INDEX=1 TRANSMIT=0     # Comment out this line if not using a btt_mini12864
+    SET_LED LED=btt_mini12864 RED={R} GREEN={G} BLUE={B} INDEX=2 TRANSMIT=0     # Comment out this line if not using a btt_mini12864
+    SET_LED LED=btt_mini12864 RED={R} GREEN={G} BLUE={B} INDEX=3 TRANSMIT=1     # Comment out this line if not using a btt_mini12864
 
 [gcode_macro DIM_LIGHTS]
 description: Set lights to a dim preset
@@ -42,18 +42,17 @@ gcode:
 [gcode_macro _status_presets]
 variable_off: -99
 variable_lookup: {
-        'off': -99,
-        'ready': 45,
-        'busy':  43,
-        'heating': 41,
-        'leveling': 40,
+        'off': -99,                  ## equivelent to not set in WLED
+        'ready': 45,                 ## if you see the word "ready" apply preset 45
+        'busy':  43,                 ## if you see the word "busy" apply preset 43
+        'heating': 41,               ## if you see the word "heating" apply preset 41
+        'leveling': 40,              ## etc... feel free to add more states / change numbers to match your WLED setup
         'homing': 40,
         'cleaning': 40,
         'meshing': 40,
         'calibrating z': 40,
         'printing': 46,
-        'complete': 42,
-        'busy':  43
+        'complete': 42
     }
 gcode:
     # Do nothing

--- a/macros.d/wled.cfg
+++ b/macros.d/wled.cfg
@@ -6,7 +6,7 @@
 [gcode_macro WLED_ON]
 description: Turn WLED strip on using optional preset
 gcode:
-  {% set strip = params.STRIP|string %}
+  {% set strip = params.STRIP|default('lights')|string %}
   {% set preset = params.PRESET|default(-1)|int %}
 
   {action_call_remote_method("set_wled_state",
@@ -17,7 +17,7 @@ gcode:
 [gcode_macro WLED_OFF]
 description: Turn WLED strip off
 gcode:
-  {% set strip = params.STRIP|string %}
+  {% set strip = params.STRIP|default('lights')|string %}
 
   {action_call_remote_method("set_wled_state",
                              strip=strip,
@@ -26,7 +26,7 @@ gcode:
 [gcode_macro SET_WLED]
 description: SET_LED like functionlity for WLED
 gcode:
-    {% set strip = params.STRIP|string %}
+    {% set strip = params.STRIP|default('lights')|string %}
     {% set red = params.RED|default(0)|float %}
     {% set green = params.GREEN|default(0)|float %}
     {% set blue = params.BLUE|default(0)|float %}


### PR DESCRIPTION
- macros.d/wled.cfg
  - Added default STRIP parameter so you don't have to type lights all the time!
- macros.d/lights.cfg
  - added comments on lines with btt_mini12864 to highlight the need to comment it out (so users can prevent console errors)
  - added comments to _status_presets to aid understanding
  - removed duplicate 'busy',43 keypair.